### PR TITLE
ci(token-contracts): add gitleaks secret scanning

### DIFF
--- a/.github/workflows/gitleaks.yml
+++ b/.github/workflows/gitleaks.yml
@@ -1,0 +1,45 @@
+# Secret scanning with gitleaks
+#
+# Scans the FULL git history (fetch-depth: 0) on every PR/push to main, on a
+# weekly schedule, and on demand. Fails the run if a real secret is found.
+#
+# We install the gitleaks binary directly instead of using gitleaks-action,
+# because gitleaks-action requires a paid GITLEAKS_LICENSE for repos owned by
+# an organization. The binary itself is free and unrestricted.
+#
+# Confirmed false positives (public on-chain addresses, Solidity error
+# identifiers, deployment artifacts) are suppressed via .gitleaks.toml.
+name: gitleaks
+
+on:
+  pull_request:
+    branches: [main, develop]
+  push:
+    branches: [main, develop]
+  schedule:
+    - cron: '0 9 * * 1' # weekly full-history scan, Mondays 09:00 UTC
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  scan:
+    name: Scan for secrets
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout (full history)
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Install gitleaks
+        run: |
+          VERSION=8.30.1
+          curl -sSfL "https://github.com/gitleaks/gitleaks/releases/download/v${VERSION}/gitleaks_${VERSION}_linux_x64.tar.gz" -o gitleaks.tar.gz
+          tar -xzf gitleaks.tar.gz gitleaks
+          sudo install gitleaks /usr/local/bin/gitleaks
+          gitleaks version
+
+      - name: Scan full git history
+        run: gitleaks git . --config .gitleaks.toml --redact --verbose --exit-code 1

--- a/.gitleaks.toml
+++ b/.gitleaks.toml
@@ -1,0 +1,27 @@
+# gitleaks configuration for token-contracts
+#
+# Extends the full built-in ruleset (AWS keys, GitHub PATs, private keys, etc.)
+# and only suppresses false positives confirmed during the 2026-06-21 audit.
+#
+# IMPORTANT: the allowlist is deliberately narrow. It does NOT blanket-exempt
+# test files or 64-hex values, so a real private key or API key committed
+# anywhere will still fail the scan.
+title = "TokenBot token-contracts"
+
+[extend]
+useDefault = true
+
+[allowlist]
+description = "Reviewed false positives — public on-chain data and Solidity identifiers"
+regexes = [
+  # Public EVM addresses are 20 bytes / 40 hex and are on-chain public data.
+  # Bounded with \b so 64-hex private keys are NOT suppressed by this rule.
+  '''0x[a-fA-F0-9]{40}\b''',
+  # OpenZeppelin custom-error / interface identifiers used throughout the tests,
+  # e.g. ERC20InsufficientBalance, ERC20InvalidReceiver.
+  '''ERC20[A-Za-z]+''',
+]
+paths = [
+  # Deployment artifacts hold only public mint/deployer addresses and tx signatures.
+  '''deployments/.*\.json$''',
+]

--- a/.gitleaksignore
+++ b/.gitleaksignore
@@ -1,0 +1,19 @@
+# Known, already-triaged findings that gitleaks should not re-report.
+# Format: one fingerprint per line  ->  <commit>:<file>:<rule>:<line>
+#
+# Etherscan/Basescan API key committed to .env.example history (2025-08-30).
+# Severity: low (read-only block-explorer quota; no funds/contracts/keys).
+# Action: ROTATE the key at etherscan.io, then this value in history is dead.
+# These entries only document the historical commit; remove them if the git
+# history is ever rewritten to purge the value.
+a35d09f7e102cfb51af82e0259cd625269980b2c:.env.example:generic-api-key:40
+a35d09f7e102cfb51af82e0259cd625269980b2c:.env.example:generic-api-key:43
+
+# Documentation placeholders (NOT secrets) — reviewed 2026-06-21.
+# These are illustrative values in docs that no longer exist at HEAD:
+#   DEPLOYER_PRIVATE_KEY=abc123def456...   (literal placeholder)
+#   TokenBotL1: "0x742d35cc6464c9532...8df31fa93"  (truncated example address)
+#   TokenBotL2: "0x123abc...def456"        (truncated example address)
+696d54b844eb1b1ae25c99e6611de3d6cfc24db7:docs/ENVIRONMENT_SETUP.md:generic-api-key:138
+a70cd9186e1b5d3ca57331ed29f99a336eb4ed59:docs/VERIFICATION.md:generic-api-key:136
+a70cd9186e1b5d3ca57331ed29f99a336eb4ed59:docs/VERIFICATION.md:generic-api-key:139

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,13 @@
+# Pre-commit hooks for token-contracts.
+#
+# One-time setup per clone:
+#   pip install pre-commit   # or: brew install pre-commit
+#   pre-commit install
+#
+# After that, gitleaks scans your staged changes before every commit and blocks
+# the commit if a secret is detected. It automatically picks up .gitleaks.toml.
+repos:
+  - repo: https://github.com/gitleaks/gitleaks
+    rev: v8.30.1
+    hooks:
+      - id: gitleaks


### PR DESCRIPTION
## What

Adds [gitleaks](https://github.com/gitleaks/gitleaks) secret scanning to this repo.

- **`.github/workflows/gitleaks.yml`** — scans the **full git history** on PRs/pushes to `main`+`develop`, weekly, and on demand. Fails the run on any newly committed secret.
- **`.gitleaks.toml`** — extends the default ruleset; allowlists confirmed false-positive *classes* (public EVM addresses, OpenZeppelin error identifiers, `deployments/*.json` artifacts).
- **`.gitleaksignore`** — pins known, already-triaged historical findings by fingerprint.
- **`.pre-commit-config.yaml`** — optional local hook (`pre-commit install`) to catch secrets before they're committed.

## Why

A history audit of the public repos turned up one real low-severity leak here: an Etherscan/Basescan API key committed to `.env.example` history (2025-08-30, already removed from HEAD). It's read-only block-explorer access — no funds/contracts/keys — and the key is being rotated separately. This workflow prevents recurrence and gives the same guardrail to the rest of the org via a template (`.github` repo).

## Validation

- Full-history scan with this config returns **`no leaks found`** (was 21 raw hits — 20 false positives, 1 real documented in `.gitleaksignore`).
- A planted AWS/GitHub token still **fails** the scan, confirming detection isn't blinded.
- Installs the gitleaks **binary** directly rather than `gitleaks-action`, which requires a paid `GITLEAKS_LICENSE` for org-owned repos.

> Note: `.gitleaksignore` documents the historical Etherscan key. Rotating the key makes that value dead; the entry can be removed entirely if history is ever rewritten.

🤖 Generated with [Claude Code](https://claude.com/claude-code)