### PR TITLE
fix(token-contracts): drop CI step calling missing test:l2 script

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,10 +35,7 @@ jobs:
         
       - name: Run L1 tests
         run: npm run test:l1
-        
-      - name: Run L2 tests
-        run: npm run test:l2
-        
+
       - name: Generate gas report
         run: npm run test:gas
         env:


### PR DESCRIPTION
## Problem

The `test` job (matrix `node-version: [18.x, 20.x]`) has been failing on `main`, which is why `test (18.x)` and `test (20.x)` show red. The failure is **not** a test failure — it's a missing npm script:

```
Run npm run test:l2
npm error Missing script: "test:l2"
##[error]Process completed with exit code 1.
```

There is no `test:l2` script in `package.json` and no `test/TokenBotL2.test.js`. L2 / multichain behavior is covered by `test/MultiChainDeployment.test.js`, which already runs under `npm test` (the `Run tests` step). The `Run L2 tests` step was stale — left behind when the separate L2 suite was consolidated.

## Fix

Remove the single stale `Run L2 tests` step. No test coverage is lost: `npm test` runs the entire `test/` directory (L1 + multichain + deployment-script suites).

## Verification (local)

| command | result |
|---|---|
| `npm test` | 46 passing |
| `npm run test:l1` | 26 passing |
| `npm run test:gas` | 46 passing |

CI on this PR will confirm `test (18.x)` and `test (20.x)` go green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)